### PR TITLE
Update _gulpfile.js to fix gulp-processhtml call which breaks with the latest version

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -88,7 +88,7 @@ gulp.task('minifycss', ['clean'], function () {
 
 gulp.task('processhtml', ['clean'], function() {
   return gulp.src('src/index.html')
-    .pipe(processhtml('index.html'))
+    .pipe(processhtml())
     .pipe(gulp.dest(paths.dist))
     .on('error', gutil.log);
 });


### PR DESCRIPTION
To give the file name as a parameter in processhtml is not correct and actually breaks it with the most recent version of gulp-processhtml.
There has to be an actually valid htmlprocessor processor, but the filename is definately not a valid option.
This will make it work again with the latest gulp-processhtml
