### PR TITLE
Can't run 'gulp' because of missing dependency

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -22,6 +22,7 @@
     "gulp-uglify": "*",
     "gulp-connect": "*",
     "gulp-watch": "*",
+    "jshint": "^2.9.1",
     "browserify": "*",
     "tiny-lr": "*",
     "vinyl-source-stream": "*",


### PR DESCRIPTION
When running npm install i got the error message 'npm WARN gulp-jshint@2.0.0 requires a peer of jshint@2.x but none was installed.' and gulp wouldn't run.
After adding jshint to the mix it worked without any problem.
